### PR TITLE
Add generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlx-rs"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 license = "CC0-1.0"
 description = "Implementation of dancing links in Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlx-rs"
-version = "2.0.0"
+version = "1.2.0"
 edition = "2021"
 license = "CC0-1.0"
 description = "Implementation of dancing links in Rust"

--- a/README.md
+++ b/README.md
@@ -44,16 +44,28 @@
  The code to solve this is
  ```rust
  use dlx_rs::Solver;
+
+ // Define options, must have these three traits (can also use a String)
+ #[derive(Clone, PartialEq, Debug)]
+ enum Opts {
+     O1,
+     O2,
+     O3,
+     O4,
+     O5,
+     O6
+ }
+
  let mut s = Solver::new(7);
- s.add_option("o1",&[3,5])
-     .add_option("o2",&[1,5,7])
-     .add_option("o3",&[2,3,6])
-     .add_option("o4",&[1,4,6])
-     .add_option("o5",&[2,7])
-     .add_option("o6",&[4,5,7]);
+ s.add_option(Opts::O1, &[3, 5])
+     .add_option(Opts::O2, &[1, 5, 7])
+     .add_option(Opts::O3, &[2, 3, 6])
+     .add_option(Opts::O4, &[1, 4, 6])
+     .add_option(Opts::O5, &[2, 7])
+     .add_option(Opts::O6, &[4, 5, 7]);
 
  let sol = s.next().unwrap_or_default();
- assert_eq!(sol,["o4","o5","o1"]);
+ assert_eq!(sol,[Opts::O4,Opts::O5,Opts::O1]);
 
  ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@
  ```rust
  use dlx_rs::Solver;
 
- // Define options, must have these three traits (can also use a String)
  #[derive(Clone, PartialEq, Debug)]
  enum Opts {
      O1,
@@ -53,7 +52,7 @@
      O3,
      O4,
      O5,
-     O6
+     O6,
  }
 
  let mut s = Solver::new(7);
@@ -65,12 +64,26 @@
      .add_option(Opts::O6, &[4, 5, 7]);
 
  let sol = s.next().unwrap_or_default();
- assert_eq!(sol,[Opts::O4,Opts::O5,Opts::O1]);
-
+ assert_eq!(sol, [Opts::O4, Opts::O5, Opts::O1]);
  ```
 
- ## Solving a Sudoku
+ Or, we can use strings in a case where we might want to generate the options at runtime
 
+ ```rust
+ use dlx_rs::Solver;
+
+ let mut s = Solver::new(7);
+ s.add_option("o1", &[3, 5])
+     .add_option("o2", &[1, 5, 7])
+     .add_option("o3", &[2, 3, 6])
+     .add_option("o4", &[1, 4, 6])
+     .add_option("o5", &[2, 7])
+     .add_option("o6", &[4, 5, 7]);
+
+ let sol = s.next().unwrap_or_default();
+ assert_eq!(sol, ["o4", "o5", "o1"]);
+ ```
+ ## Solving a Sudoku
 
  ```rust
  use dlx_rs::Sudoku;

--- a/src/aztec.rs
+++ b/src/aztec.rs
@@ -20,7 +20,7 @@ enum Color {
 /// ```
 pub struct Aztec {
     n: usize,
-    solver: Solver,
+    solver: Solver<String>,
 }
 
 impl Aztec {
@@ -69,7 +69,7 @@ impl Aztec {
                 let pos1 = x;
                 let pos2 = pos1 + 1;
                 let con_name = format!("H{}#{}", pos1, pos2);
-                solver.add_option(&con_name, &[pos1, pos2]);
+                solver.add_option(con_name, &[pos1, pos2]);
             }
         }
 
@@ -81,14 +81,14 @@ impl Aztec {
                 let pos2 = pos1 + 2 * j + 1;
 
                 let con_name = format!("V{}#{}", pos1, pos2);
-                solver.add_option(&con_name, &[pos1, pos2]);
+                solver.add_option(con_name, &[pos1, pos2]);
 
                 // Now add mirror image of this
                 let mpos1 = max - pos1 + 1;
                 let mpos2 = max - pos2 + 1;
 
                 let mcon_name = format!("V{}#{}", mpos2, mpos1);
-                solver.add_option(&mcon_name, &[mpos2, mpos1]);
+                solver.add_option(mcon_name, &[mpos2, mpos1]);
             }
         }
         // Final (biggest row), runs from n(n-1) + 1 -> n(n-1) + 1 + 2n -1, and pairs with
@@ -99,7 +99,7 @@ impl Aztec {
             let pos2 = x + 2 * n;
 
             let con_name = format!("V{}#{}", pos1, pos2);
-            solver.add_option(&con_name, &[pos1, pos2]);
+            solver.add_option(con_name, &[pos1, pos2]);
         }
 
         Aztec { solver, n }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,16 +37,28 @@
 //! The code to solve this is
 //! ```
 //! use dlx_rs::Solver;
+//!
+//! // Define options, must have these three traits (can also use a String)
+//! #[derive(Clone, PartialEq, Debug)]
+//! enum Opts {
+//!     O1,
+//!     O2,
+//!     O3,
+//!     O4,
+//!     O5,
+//!     O6
+//! }
+//!
 //! let mut s = Solver::new(7);
-//! s.add_option("o1".to_string(), &[3, 5])
-//!     .add_option("o2".to_string(), &[1, 5, 7])
-//!     .add_option("o3".to_string(), &[2, 3, 6])
-//!     .add_option("o4".to_string(), &[1, 4, 6])
-//!     .add_option("o5".to_string(), &[2, 7])
-//!     .add_option("o6".to_string(), &[4, 5, 7]);
+//! s.add_option(Opts::O1, &[3, 5])
+//!     .add_option(Opts::O2, &[1, 5, 7])
+//!     .add_option(Opts::O3, &[2, 3, 6])
+//!     .add_option(Opts::O4, &[1, 4, 6])
+//!     .add_option(Opts::O5, &[2, 7])
+//!     .add_option(Opts::O6, &[4, 5, 7]);
 //!
 //! let sol = s.next().unwrap_or_default();
-//! assert_eq!(sol,["o4","o5","o1"]);
+//! assert_eq!(sol,[Opts::O4,Opts::O5,Opts::O1]);
 //!
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,12 +38,12 @@
 //! ```
 //! use dlx_rs::Solver;
 //! let mut s = Solver::new(7);
-//! s.add_option("o1", &[3, 5])
-//!     .add_option("o2", &[1, 5, 7])
-//!     .add_option("o3", &[2, 3, 6])
-//!     .add_option("o4", &[1, 4, 6])
-//!     .add_option("o5", &[2, 7])
-//!     .add_option("o6", &[4, 5, 7]);
+//! s.add_option("o1".to_string(), &[3, 5])
+//!     .add_option("o2".to_string(), &[1, 5, 7])
+//!     .add_option("o3".to_string(), &[2, 3, 6])
+//!     .add_option("o4".to_string(), &[1, 4, 6])
+//!     .add_option("o5".to_string(), &[2, 7])
+//!     .add_option("o6".to_string(), &[4, 5, 7]);
 //!
 //! let sol = s.next().unwrap_or_default();
 //! assert_eq!(sol,["o4","o5","o1"]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@
 //! ```
 //! use dlx_rs::Solver;
 //!
-//! // Define options, must have these three traits (can also use a String)
 //! #[derive(Clone, PartialEq, Debug)]
 //! enum Opts {
 //!     O1,
@@ -46,7 +45,7 @@
 //!     O3,
 //!     O4,
 //!     O5,
-//!     O6
+//!     O6,
 //! }
 //!
 //! let mut s = Solver::new(7);
@@ -58,12 +57,27 @@
 //!     .add_option(Opts::O6, &[4, 5, 7]);
 //!
 //! let sol = s.next().unwrap_or_default();
-//! assert_eq!(sol,[Opts::O4,Opts::O5,Opts::O1]);
+//! assert_eq!(sol, [Opts::O4, Opts::O5, Opts::O1]);
+//! ```
 //!
+//! Or, we can use strings in a case where we might want to generate the options at runtime
+//!
+//! ```
+//! use dlx_rs::Solver;
+//!
+//! let mut s = Solver::new(7);
+//! s.add_option("o1", &[3, 5])
+//!     .add_option("o2", &[1, 5, 7])
+//!     .add_option("o3", &[2, 3, 6])
+//!     .add_option("o4", &[1, 4, 6])
+//!     .add_option("o5", &[2, 7])
+//!     .add_option("o6", &[4, 5, 7]);
+//!
+//! let sol = s.next().unwrap_or_default();
+//! assert_eq!(sol, ["o4", "o5", "o1"]);
 //! ```
 //!
 //! ## Solving a Sudoku
-//!
 //!
 //! ```
 //! use dlx_rs::Sudoku;
@@ -99,7 +113,6 @@
 //! assert_eq!(solution, true_solution);
 //! assert_eq!(s.next(), None);
 //! ```
-//!
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 pub mod aztec;

--- a/src/queens.rs
+++ b/src/queens.rs
@@ -12,7 +12,7 @@ use crate::Solver;
 /// ```
 pub struct Queens {
     n: usize,
-    solver: Solver,
+    solver: Solver<String>,
 }
 
 impl Queens {
@@ -51,7 +51,7 @@ impl Queens {
                 // 6*N-1 -> N**2 + 6*N - 2
                 let is_queen = 6 * n - 2 + r + n * (c - 1);
 
-                solver.add_option(&con_name, &[col_con, row_con, rd_con, ld_con, is_queen]);
+                solver.add_option(con_name, &[col_con, row_con, rd_con, ld_con, is_queen]);
             }
         }
 

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt::{self, Display};
+use std::fmt::{self, Debug};
 type Index = usize;
 
 #[derive(Clone, Debug)]
@@ -77,7 +77,7 @@ struct Item {
 #[derive(Clone)]
 pub struct Solver<T>
 where
-    T: std::fmt::Display + PartialEq + Clone,
+    T: std::fmt::Debug + PartialEq + Clone,
 {
     elements: Vec<Link>,
     items: Index,
@@ -104,7 +104,7 @@ enum Stage {
     X8,
 }
 
-impl<T: std::fmt::Display + PartialEq + Clone> fmt::Display for Solver<T> {
+impl<T: std::fmt::Debug + PartialEq + Clone> fmt::Display for Solver<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // First write columns
         let mut last_col = 1;
@@ -240,7 +240,7 @@ impl Link for Spacer {
 }
 */
 
-impl<T: PartialEq + Display + Clone> Solver<T> {
+impl<T: PartialEq + Debug + Clone> Solver<T> {
     /// Returns a solver with `n` items, all of which must be covered exactly
     /// once
     pub fn new(n: Index) -> Self {
@@ -854,7 +854,7 @@ impl<T: PartialEq + Display + Clone> Solver<T> {
     }
 }
 
-impl<T: Display + PartialEq + Clone> Iterator for Solver<T> {
+impl<T: Debug + PartialEq + Clone> Iterator for Solver<T> {
     type Item = Vec<T>;
     /// Produces next solution by following algorithm X
     /// as described in tAoCP in Fasc 5c, Dancing Links, Knuth

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -819,15 +819,7 @@ impl<T: PartialEq + Debug + Clone> Solver<T> {
             Some(z) => z,
             None => return Err("Invalid option specified"),
         };
-        /*
-        let mut id =0;
-        for (i,item) in self.names.iter().enumerate() {
-            if *item == name.to_string() {
-                id = i;
-                break;
-            }
-        }
-        */
+
         // Now find the spacer id by going this many links down the chain
         // Start at root spacer node
         let mut spacer_id = self.items + 1;

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fmt;
+use std::fmt::{self, Display};
 type Index = usize;
 
 #[derive(Clone, Debug)]
@@ -75,7 +75,10 @@ struct Item {
 ///# }
 /// ```
 #[derive(Clone)]
-pub struct Solver {
+pub struct Solver<T>
+where
+    T: std::fmt::Display + PartialEq + Clone,
+{
     elements: Vec<Link>,
     items: Index,
     options: HashMap<Index, Vec<Index>>,
@@ -83,7 +86,7 @@ pub struct Solver {
     sol_vec: Vec<Index>,
     yielding: bool,
     idx: Index,
-    names: Vec<String>,
+    names: Vec<T>,
     spacer_ids: HashMap<Index, usize>,
     stage: Stage,
     optional: Index,
@@ -101,7 +104,7 @@ enum Stage {
     X8,
 }
 
-impl fmt::Display for Solver {
+impl<T: std::fmt::Display + PartialEq + Clone> fmt::Display for Solver<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // First write columns
         let mut last_col = 1;
@@ -237,7 +240,7 @@ impl Link for Spacer {
 }
 */
 
-impl Solver {
+impl<T: PartialEq + Display + Clone> Solver<T> {
     /// Returns a solver with `n` items, all of which must be covered exactly
     /// once
     pub fn new(n: Index) -> Self {
@@ -357,7 +360,7 @@ impl Solver {
     /// o5     ⦿      ⦿     ⥯     ⥯   s5
     ///        ⥯      ⥯     ⥯     ⥯
     /// ```
-    pub fn add_option(&mut self, name: &str, option: &[Index]) -> &mut Self {
+    pub fn add_option(&mut self, name: T, option: &[Index]) -> &mut Self {
         // Increase max depth, come back to this later
         self.sol_vec.push(0);
         //        self.sol_vec.push(0);
@@ -397,7 +400,7 @@ impl Solver {
 
         // Add the entry to the hash table
         self.options.insert(spacer_index, option.to_vec());
-        self.names.push(String::from(name));
+        self.names.push(name.clone());
         self.spacer_ids.insert(spacer_index, self.names.len() - 1);
 
         self
@@ -542,7 +545,7 @@ impl Solver {
 
     /// Implements algorithm X as a finite state machine
     #[allow(dead_code)]
-    pub fn solve(&mut self) -> Option<Vec<String>> {
+    pub fn solve(&mut self) -> Option<Vec<T>> {
         // Follows stages of algorithm description in Fasc 5c, Knuth
 
         // The only ways to break this loop are to yield a solution via X2 or to
@@ -582,7 +585,7 @@ impl Solver {
     ///
     // TODO: Is it useful to have the double map? We don't used spacer_ids for
     //       anything else, so could condense it into a single HashMap
-    pub fn output(&self) -> Vec<String> {
+    pub fn output(&self) -> Vec<T> {
         let to_return = self
             .sol_vec
             .iter()
@@ -597,7 +600,7 @@ impl Solver {
     /// Stage X2 of Algorithm X
     /// If rlink(0) = 0, then all items are covered, so return current solution
     /// and also go to X8
-    fn x2(&mut self) -> Option<Vec<String>> {
+    fn x2(&mut self) -> Option<Vec<T>> {
         //println!("State:");
         //println!("{}",self);
         //println!("RLINK: {}",self.elements[0].r());
@@ -792,32 +795,27 @@ impl Solver {
     ///
     /// let mut s = Solver::new(3);
     ///
-    /// s.add_option("o1", &[1])
-    ///     .add_option("o2", &[1])
-    ///     .add_option("o3", &[2, 3]);
+    /// s.add_option("o1".to_string(), &[1])
+    ///     .add_option("o2".to_string(), &[1])
+    ///     .add_option("o3".to_string(), &[2, 3]);
     ///
     /// // First get all solutions
     /// let sols: Vec<Vec<String>> = s.clone().collect();
     /// assert_eq!( sols.len(), 2);
-    /// assert_eq!( vec!["o3", "o1"], sols[0]);
-    /// assert_eq!( vec!["o3", "o2"], sols[1]);
+    /// assert_eq!( vec!["o3".to_string(), "o1".to_string()], sols[0]);
+    /// assert_eq!( vec!["o3".to_string(), "o2".to_string()], sols[1]);
     ///
     ///
     /// // Now select o1 and get all solutions
-    /// s.select("o1");
-    /// assert_eq!( vec!["o3"], s.next().unwrap());
+    /// s.select(&"o1".to_string());
+    /// assert_eq!( vec!["o3".to_string()], s.next().unwrap());
     /// ```
-    pub fn select(&mut self, name: &str) -> Result<(), &'static str> {
+    pub fn select(&mut self, name: &T) -> Result<(), &'static str> {
         // This selects an option by doing the followings
 
         // First get the spacer position of the option by firstly finding which
         // option it was
-        let id = match self
-            .names
-            .clone()
-            .iter()
-            .position(|x| x == &name.to_string())
-        {
+        let id = match self.names.iter().position(|x| x == name) {
             Some(z) => z,
             None => return Err("Invalid option specified"),
         };
@@ -856,8 +854,8 @@ impl Solver {
     }
 }
 
-impl Iterator for Solver {
-    type Item = Vec<String>;
+impl<T: Display + PartialEq + Clone> Iterator for Solver<T> {
+    type Item = Vec<T>;
     /// Produces next solution by following algorithm X
     /// as described in tAoCP in Fasc 5c, Dancing Links, Knuth
     ///

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -795,27 +795,27 @@ impl<T: PartialEq + Debug + Clone> Solver<T> {
     ///
     /// let mut s = Solver::new(3);
     ///
-    /// s.add_option("o1".to_string(), &[1])
-    ///     .add_option("o2".to_string(), &[1])
-    ///     .add_option("o3".to_string(), &[2, 3]);
+    /// s.add_option("o1", &[1])
+    ///     .add_option("o2", &[1])
+    ///     .add_option("o3", &[2, 3]);
     ///
     /// // First get all solutions
-    /// let sols: Vec<Vec<String>> = s.clone().collect();
-    /// assert_eq!( sols.len(), 2);
-    /// assert_eq!( vec!["o3".to_string(), "o1".to_string()], sols[0]);
-    /// assert_eq!( vec!["o3".to_string(), "o2".to_string()], sols[1]);
+    /// let sols: Vec<Vec<&str>> = s.clone().collect();
+    /// assert_eq!(sols.len(), 2);
+    /// assert_eq!( vec!["o3", "o1"], sols[0]);
+    /// assert_eq!( vec!["o3", "o2"], sols[1]);
     ///
     ///
     /// // Now select o1 and get all solutions
-    /// s.select(&"o1".to_string());
+    /// s.select("o1");
     /// assert_eq!( vec!["o3".to_string()], s.next().unwrap());
     /// ```
-    pub fn select(&mut self, name: &T) -> Result<(), &'static str> {
+    pub fn select(&mut self, name: T) -> Result<(), &'static str> {
         // This selects an option by doing the followings
 
         // First get the spacer position of the option by firstly finding which
         // option it was
-        let id = match self.names.iter().position(|x| x == name) {
+        let id = match self.names.iter().position(|x| x == &name) {
             Some(z) => z,
             None => return Err("Invalid option specified"),
         };

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -808,7 +808,7 @@ impl<T: PartialEq + Debug + Clone> Solver<T> {
     ///
     /// // Now select o1 and get all solutions
     /// s.select("o1");
-    /// assert_eq!( vec!["o3".to_string()], s.next().unwrap());
+    /// assert_eq!( vec!["o3"], s.next().unwrap());
     /// ```
     pub fn select(&mut self, name: T) -> Result<(), &'static str> {
         // This selects an option by doing the followings

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -37,7 +37,7 @@ use crate::solver::Solver;
 /// assert_eq!(s.next(), None);
 /// ```
 pub struct Sudoku {
-    pub solver: Solver,
+    pub solver: Solver<String>,
     input: Vec<usize>,
     n: usize,
 }
@@ -90,7 +90,7 @@ impl Sudoku {
                     // Runs 3*N*N+1 -> 3*N*N + N*(N-1) + N = 4*N*N
                     let sub_con = 3 * N * N + N * (sub) + val;
                     //println!("Adding constraint: {}",constraint_name);
-                    solver.add_option(&constraint_name, &[cell_con, row_con, col_con, sub_con]);
+                    solver.add_option(constraint_name, &[cell_con, row_con, col_con, sub_con]);
 
                     /*
                     if !(0 < cell_con && cell_con <= N*N) {

--- a/src/sudoku.rs
+++ b/src/sudoku.rs
@@ -137,7 +137,7 @@ impl Sudoku {
                 let col = i - n * n * row;
                 let opt_string = format!("R{}C{}#{}", row + 1, col + 1, *item);
                 //            println!("{}",opt_string);
-                s.solver.select(&opt_string).unwrap();
+                s.solver.select(opt_string).unwrap();
             }
         }
 


### PR DESCRIPTION
Change the `Solver` struct to be `Solver<T>` to incorporate generics. This retains backwards compatbility with what is now the `Solver<&str>` case, but also allows e.g. a custom enum for a discrete number of options which are known ahead of time.